### PR TITLE
truncation tag values to 50 chars and dedupe the uuid submitted

### DIFF
--- a/navi/plugins/migrate.py
+++ b/navi/plugins/migrate.py
@@ -10,7 +10,8 @@ def organize_aws_keys(aws_ec2):
     for tags in aws_ec2['Tags']:
         if tags['ResourceType'] == 'instance':
             aws_key = tags['Key']
-            aws_value = tags['Value']
+            # Truncate strings which are longer then 50 chars and add and elipse to signify the trucation.
+            aws_value = tags['Value'][:48] + (tags['Value'][48:] and '..')
             resource_id = tags['ResourceId']
 
             # Tenable IO Requires a Key and a Value; AWS does not.  In this case we just use the key as both
@@ -58,6 +59,8 @@ def migrate(region, a, s):
                 db = db_query("select uuid from assets where aws_id='{}';".format(instance))
                 for record in db:
                     uuid_list.append(record[0])
+            # Dedupe the list of uuids to avoid 500 errors from the api
+            uuid_list = list(dict.fromkeys(uuid_list))
             description = "AWS Tag by Navi"
 
             print("Creating a Tag named - {} : {} - with the following ids {}".format(key, z, w))


### PR DESCRIPTION
t.io tags are limited to 50 chars, aws tags are not, this will truncate tag values to fit in t.io. Truncated tags will add an ellipse to signify they are truncated.

The list of uuid's submitted to t.io for tagging contained duplicates which seemed to break the t.io, so a simple dedupe of the list of uuid posted resolves this.