### PR TITLE
Update th_vuln_export.py

### DIFF
--- a/navi/plugins/th_vuln_export.py
+++ b/navi/plugins/th_vuln_export.py
@@ -286,12 +286,12 @@ def vuln_export(days, ex_uuid, threads, category, value, state, severity):
     day_limit = time.time() - new_limit
 
     if category is None:
-        pay_load = {"num_assets": 50, "filters": {'last_found': int(day_limit), "state": state, "severity": severity}}
+        pay_load = {"include_unlicensed": True,"num_assets": 50, "filters": {'last_found': int(day_limit), "state": state, "severity": severity}}
     else:
         if value is None:
-            pay_load = {"num_assets": 50, "filters": {'last_found': int(day_limit), "state": state, "severity": severity}}
+            pay_load = {"include_unlicensed": True,"num_assets": 50, "filters": {'last_found': int(day_limit), "state": state, "severity": severity}}
         else:
-            pay_load = {"num_assets": 50, "filters": {'last_found': int(day_limit), "state": state, "severity": severity,
+            pay_load = {"include_unlicensed": True,"num_assets": 50, "filters": {'last_found': int(day_limit), "state": state, "severity": severity,
                                                       "tag.{}".format(category): "{}".format(value)}}
     try:
 


### PR DESCRIPTION
Fixed the number of counts with UI.  Explore --> findings shows all findings including Licensed and unLicensed whereas under the hood query hit the only Licensed asset which cases discrepancies in report count.